### PR TITLE
Add player count to title

### DIFF
--- a/src/main/java/dev/wannaknow/raidplayernames/RaidPlayerNamesBox.java
+++ b/src/main/java/dev/wannaknow/raidplayernames/RaidPlayerNamesBox.java
@@ -68,7 +68,7 @@ public class RaidPlayerNamesBox extends JPanel {
                 deleteLabel.setIcon(DELETE_ICON);
             }
         });
-        actions.add(new JLabel(type), BorderLayout.WEST);
+        actions.add(new JLabel(type + " (" + players.size() + " players)"), BorderLayout.WEST);
         actions.add(Box.createHorizontalGlue());
         actions.add(Box.createRigidArea(new Dimension(5, 0)));
         actions.add(deleteLabel, BorderLayout.EAST);


### PR DESCRIPTION
I use this plugin to check the number of players at the start of mass raids, but I have to count or copy paste the player list to a line counter tool. Having the player count in the title would make this more convenient.